### PR TITLE
fix panics on zero and one elements

### DIFF
--- a/chd_builder.go
+++ b/chd_builder.go
@@ -91,6 +91,9 @@ func tryHash(hasher *chdHasher, seen map[uint64]bool, keys [][]byte, values [][]
 func (b *CHDBuilder) Build() (*CHD, error) {
 	n := uint64(len(b.keys))
 	m := n / 2
+	if m == 0 {
+		m = 1
+	}
 
 	keys := make([][]byte, n)
 	values := make([][]byte, n)

--- a/chd_test.go
+++ b/chd_test.go
@@ -79,6 +79,39 @@ func TestCHDSerialization(t *testing.T) {
 	}
 }
 
+func TestCHDSerialization_empty(t *testing.T) {
+	cb := Builder()
+	m, err := cb.Build()
+	assert.NoError(t, err)
+	w := &bytes.Buffer{}
+	err = m.Write(w)
+	assert.NoError(t, err)
+
+	n, err := Mmap(w.Bytes())
+	assert.NoError(t, err)
+	assert.Equal(t, n.r, m.r)
+	assert.Equal(t, n.indices, m.indices)
+	assert.Equal(t, n.keys, m.keys)
+	assert.Equal(t, n.values, m.values)
+}
+
+func TestCHDSerialization_one(t *testing.T) {
+	cb := Builder()
+	cb.Add([]byte("k"), []byte("v"))
+	m, err := cb.Build()
+	assert.NoError(t, err)
+	w := &bytes.Buffer{}
+	err = m.Write(w)
+	assert.NoError(t, err)
+
+	n, err := Mmap(w.Bytes())
+	assert.NoError(t, err)
+	assert.Equal(t, n.r, m.r)
+	assert.Equal(t, n.indices, m.indices)
+	assert.Equal(t, n.keys, m.keys)
+	assert.Equal(t, n.values, m.values)
+}
+
 func BenchmarkBuiltinMap(b *testing.B) {
 	keys := []string{}
 	d := map[string]string{}


### PR DESCRIPTION
This PR fixes panics when building and reading MPHs with 0 and 1 elements.

Prior to applying the fix, the newly added tests fail (see below). My change fixes the panics, but it may have performance implications I am not aware of.

```
$ go test -test.run=empty
--- FAIL: TestCHDSerialization_empty-12 (0.00s)
panic: runtime error: index out of range [recovered]
	panic: runtime error: index out of range

goroutine 5 [running]:
testing.func·006()
	/usr/local/go/src/testing/testing.go:441 +0x181
github.com/alecthomas/unsafeslice.newSliceHeader(0xc20818a034, 0x0, 0x30, 0x2, 0xc208c2c060)
	/home/sqs/src/github.com/alecthomas/unsafeslice/unsafeslice.go:24 +0xae
github.com/alecthomas/unsafeslice.Uint16SliceFromByteSlice(0xc20818a034, 0x0, 0x30, 0x0, 0x0, 0x0)
	/home/sqs/src/github.com/alecthomas/unsafeslice/unsafeslice.go:44 +0x60
github.com/alecthomas/mph.(*sliceReader).ReadUint16Array(0xc208c28180, 0x0, 0x0, 0x0, 0x0)
	/home/sqs/src/github.com/alecthomas/mph/slicereader_fast.go:32 +0xab
github.com/alecthomas/mph.Mmap(0xc20818a024, 0x14, 0x40, 0x0, 0x0, 0x0)
	/home/sqs/src/github.com/alecthomas/mph/chd.go:81 +0x171
github.com/alecthomas/mph.TestCHDSerialization_empty(0xc208092090)
	/home/sqs/src/github.com/alecthomas/mph/chd_test.go:90 +0x274
testing.tRunner(0xc208092090, 0x88d490)
	/usr/local/go/src/testing/testing.go:447 +0xbf
created by testing.RunTests
	/usr/local/go/src/testing/testing.go:555 +0xa8b

goroutine 1 [chan receive]:
testing.RunTests(0x7a1ce8, 0x88d460, 0x4, 0x4, 0x891101)
	/usr/local/go/src/testing/testing.go:556 +0xad6
testing.(*M).Run(0xc208074000, 0x898540)
	/usr/local/go/src/testing/testing.go:485 +0x6c
main.main()
	github.com/alecthomas/mph/_test/_testmain.go:62 +0x1d5
exit status 2
FAIL	github.com/alecthomas/mph	0.051s
```

```
$ go test -test.run=one
--- FAIL: TestCHDSerialization_one-12 (0.00s)
panic: runtime error: integer divide by zero [recovered]
	panic: runtime error: integer divide by zero
[signal 0x8 code=0x1 addr=0x462a19 pc=0x462a19]

goroutine 5 [running]:
testing.func·006()
	/usr/local/go/src/testing/testing.go:441 +0x181
github.com/alecthomas/mph.(*chdHasher).HashIndexFromKey(0xc2081d2030, 0xc2081d4000, 0x1, 0x8, 0x7a3da0)
	/home/sqs/src/github.com/alecthomas/mph/chd_builder.go:188 +0x69
github.com/alecthomas/mph.(*CHDBuilder).Build(0xc208505f40, 0xc208d26020, 0x0, 0x0)
	/home/sqs/src/github.com/alecthomas/mph/chd_builder.go:120 +0x53c
github.com/alecthomas/mph.TestCHDSerialization_one(0xc20809a090)
	/home/sqs/src/github.com/alecthomas/mph/chd_test.go:101 +0x3b5
testing.tRunner(0xc20809a090, 0x88d4a8)
	/usr/local/go/src/testing/testing.go:447 +0xbf
created by testing.RunTests
	/usr/local/go/src/testing/testing.go:555 +0xa8b

goroutine 1 [chan receive]:
testing.RunTests(0x7a1ce8, 0x88d460, 0x4, 0x4, 0x891101)
	/usr/local/go/src/testing/testing.go:556 +0xad6
testing.(*M).Run(0xc20807c000, 0x898540)
	/usr/local/go/src/testing/testing.go:485 +0x6c
main.main()
	github.com/alecthomas/mph/_test/_testmain.go:62 +0x1d5
exit status 2
FAIL	github.com/alecthomas/mph	0.044s
```