### PR TITLE
Set n as a multiple of the key set size m

### DIFF
--- a/chd_builder.go
+++ b/chd_builder.go
@@ -89,11 +89,12 @@ func tryHash(hasher *chdHasher, seen map[uint64]bool, keys [][]byte, values [][]
 }
 
 func (b *CHDBuilder) Build() (*CHD, error) {
-	n := uint64(len(b.keys))
-	m := n / 2
+	const c = 2
+	m := uint64(len(b.keys))
 	if m == 0 {
 		m = 1
 	}
+	n := 1 + c*m
 
 	keys := make([][]byte, n)
 	values := make([][]byte, n)

--- a/slicereader_fast.go
+++ b/slicereader_fast.go
@@ -19,6 +19,9 @@ type sliceReader struct {
 
 func (b *sliceReader) Read(size uint64) []byte {
 	b.start, b.end = b.end, b.end+size
+	if b.start == b.end {
+		return nil
+	}
 	return b.b[b.start:b.end]
 }
 

--- a/slicereader_safe.go
+++ b/slicereader_safe.go
@@ -14,6 +14,9 @@ type sliceReader struct {
 
 func (b *sliceReader) Read(size uint64) []byte {
 	b.start, b.end = b.end, b.end+size
+	if b.start == b.end {
+		return nil
+	}
 	return b.b[b.start:b.end]
 }
 


### PR DESCRIPTION
See discussion at https://github.com/alecthomas/mph/issues/6 for background. I was finding that mph failed to generate collision-free hashes for simple key sets. Digging into the paper revealed to me some differences between how it recommends setting `m` and what mph was doing. This PR makes mph choose `m=len(keys)` and then sets `n` as a multiple of `m`, instead of the previous way of setting `n=len(keys)` and then `m=n/2`. This PR makes the included test cases pass; without it, they often fail.

Again, I am not super familiar with MPHs or CHD although I did read the paper and have an undergraduate-level education in theoretical CS. So, please let me know if I've misunderstood anything.