### PR TITLE
update github.com/stretchr/testify

### DIFF
--- a/chd_test.go
+++ b/chd_test.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/stretchrcom/testify/assert"
+	"github.com/stretchr/testify/assert"
 )
 
 var (


### PR DESCRIPTION
`github.com/stretchrcom/testify` is old path (redirect by github)
actual is `github.com/stretchr/testify`

It makes trouble with go modules.
