### PR TITLE
slicereader: Use a local variable instead of a struct member

### DIFF
--- a/slicereader_fast.go
+++ b/slicereader_fast.go
@@ -13,23 +13,26 @@ import (
 // written in little endian form, this of course means that this will only
 // work on little-endian architectures.
 type sliceReader struct {
-	b          []byte
-	start, end uint64
+	b   []byte
+	pos uint64
 }
 
 func (b *sliceReader) Read(size uint64) []byte {
-	b.start, b.end = b.end, b.end+size
-	return b.b[b.start:b.end]
+	start := b.pos
+	b.pos += size
+	return b.b[start:b.pos]
 }
 
 func (b *sliceReader) ReadUint64Array(n uint64) []uint64 {
-	b.start, b.end = b.end, b.end+n*8
-	return unsafeslice.Uint64SliceFromByteSlice(b.b[b.start:b.end])
+	start := b.pos
+	b.pos += n * 8
+	return unsafeslice.Uint64SliceFromByteSlice(b.b[start:b.pos])
 }
 
 func (b *sliceReader) ReadUint16Array(n uint64) []uint16 {
-	b.start, b.end = b.end, b.end+n*2
-	return unsafeslice.Uint16SliceFromByteSlice(b.b[b.start:b.end])
+	start := b.pos
+	b.pos += n * 2
+	return unsafeslice.Uint16SliceFromByteSlice(b.b[start:b.pos])
 }
 
 // Despite returning a uint64, this actually reads a uint32. All table indices

--- a/slicereader_safe.go
+++ b/slicereader_safe.go
@@ -8,19 +8,19 @@ import (
 
 // Read values and typed vectors from a byte slice without copying where possible.
 type sliceReader struct {
-	b          []byte
-	start, end uint64
+	b   []byte
+	pos uint64
 }
 
 func (b *sliceReader) Read(size uint64) []byte {
-	b.start, b.end = b.end, b.end+size
-	return b.b[b.start:b.end]
+	start := b.pos
+	b.pos += size
+	return b.b[start:b.pos]
 }
 
 func (b *sliceReader) ReadUint64Array(n uint64) []uint64 {
-	b.start, b.end = b.end, b.end+n*8
+	buf := b.Read(n * 8)
 	out := make([]uint64, n)
-	buf := b.b[b.start:b.end]
 	for i := 0; i < len(buf); i += 8 {
 		out[i>>3] = binary.LittleEndian.Uint64(buf[i : i+8])
 	}
@@ -28,9 +28,8 @@ func (b *sliceReader) ReadUint64Array(n uint64) []uint64 {
 }
 
 func (b *sliceReader) ReadUint16Array(n uint64) []uint16 {
-	b.start, b.end = b.end, b.end+n*2
+	buf := b.Read(n * 2)
 	out := make([]uint16, n)
-	buf := b.b[b.start:b.end]
 	for i := 0; i < len(buf); i += 2 {
 		out[i>>1] = binary.LittleEndian.Uint16(buf[i : i+2])
 	}


### PR DESCRIPTION
It took me a second to understand that b.start isn't actually used to persist anything. Using a local variable for this seems simpler.

Also exposing it as a single variable makes my next commit a tiny bit easier to understand.