### PR TITLE
Reduce the number of pointers created in Mmap()

### DIFF
--- a/chd.go
+++ b/chd.go
@@ -44,8 +44,14 @@ type CHD struct {
 	// more than 2^16 hash functions O_o
 	indices []uint16
 	// Final table of values.
-	keys   [][]byte
-	values [][]byte
+	mmap   []byte
+	keys   []dataSlice
+	values []dataSlice
+}
+
+type dataSlice struct {
+	start uint64
+	end   uint64
 }
 
 func hasher(data []byte) uint64 {
@@ -68,7 +74,7 @@ func Read(r io.Reader) (*CHD, error) {
 
 // Mmap creates a new CHD aliasing the CHD structure over an existing byte region (typically mmapped).
 func Mmap(b []byte) (*CHD, error) {
-	c := &CHD{}
+	c := &CHD{mmap: b}
 
 	bi := &sliceReader{b: b}
 
@@ -82,17 +88,25 @@ func Mmap(b []byte) (*CHD, error) {
 
 	el := bi.ReadInt()
 
-	c.keys = make([][]byte, el)
-	c.values = make([][]byte, el)
+	c.keys = make([]dataSlice, el)
+	c.values = make([]dataSlice, el)
 
 	for i := uint64(0); i < el; i++ {
 		kl := bi.ReadInt()
 		vl := bi.ReadInt()
-		c.keys[i] = bi.Read(kl)
-		c.values[i] = bi.Read(vl)
+		c.keys[i].start = bi.pos
+		bi.pos += kl
+		c.keys[i].end = bi.pos
+		c.values[i].start = bi.pos
+		bi.pos += vl
+		c.values[i].end = bi.pos
 	}
 
 	return c, nil
+}
+
+func (c *CHD) slice(s dataSlice) []byte {
+	return c.mmap[s.start:s.end]
 }
 
 // Get an entry from the hash table.
@@ -109,11 +123,11 @@ func (c *CHD) Get(key []byte) []byte {
 	ti := (h ^ r) % uint64(len(c.keys))
 	// fmt.Printf("r[0]=%d, h=%d, i=%d, ri=%d, r=%d, ti=%d\n", c.r[0], h, i, ri, r, ti)
 	k := c.keys[ti]
-	if bytes.Compare(k, key) != 0 {
+	if bytes.Compare(c.slice(k), key) != 0 {
 		return nil
 	}
 	v := c.values[ti]
-	return v
+	return c.slice(v)
 }
 
 func (c *CHD) Len() int {
@@ -152,13 +166,13 @@ func (c *CHD) Write(w io.Writer) error {
 
 	for i := range c.keys {
 		k, v := c.keys[i], c.values[i]
-		if err := write(uint32(len(k)), uint32(len(v))); err != nil {
+		if err := write(uint32(k.end-k.start), uint32(v.end-v.start)); err != nil {
 			return err
 		}
-		if _, err := w.Write(k); err != nil {
+		if _, err := w.Write(c.slice(k)); err != nil {
 			return err
 		}
-		if _, err := w.Write(v); err != nil {
+		if _, err := w.Write(c.slice(v)); err != nil {
 			return err
 		}
 	}
@@ -171,7 +185,7 @@ type Iterator struct {
 }
 
 func (c *Iterator) Get() (key []byte, value []byte) {
-	return c.c.keys[c.i], c.c.values[c.i]
+	return c.c.slice(c.c.keys[c.i]), c.c.slice(c.c.values[c.i])
 }
 
 func (c *Iterator) Next() *Iterator {

--- a/chd_builder.go
+++ b/chd_builder.go
@@ -1,6 +1,7 @@
 package mph
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"math/rand"
@@ -164,11 +165,24 @@ nextBucket:
 	// println("keys:", len(table))
 	// println("hash functions:", len(hasher.r))
 
+	keylist := make([]dataSlice, len(b.keys))
+	valuelist := make([]dataSlice, len(b.values))
+	var buf bytes.Buffer
+	for i, k := range keys {
+		keylist[i].start = uint64(buf.Len())
+		buf.Write(k)
+		keylist[i].end = uint64(buf.Len())
+		valuelist[i].start = uint64(buf.Len())
+		buf.Write(values[i])
+		valuelist[i].end = uint64(buf.Len())
+	}
+
 	return &CHD{
 		r:       hasher.r,
 		indices: indices,
-		keys:    keys,
-		values:  values,
+		mmap:    buf.Bytes(),
+		keys:    keylist,
+		values:  valuelist,
 	}, nil
 }
 

--- a/chd_test.go
+++ b/chd_test.go
@@ -43,6 +43,14 @@ func init() {
 	}
 }
 
+func cmpDataSlice(t *testing.T, cl, cr *CHD, l, r []dataSlice) {
+	t.Helper()
+	assert.Equal(t, len(l), len(r))
+	for i := 0; len(l) > i; i++ {
+		assert.Equal(t, cl.slice(l[i]), cr.slice(r[i]))
+	}
+}
+
 func TestCHDBuilder(t *testing.T) {
 	b := Builder()
 	for k, v := range sampleData {
@@ -72,8 +80,8 @@ func TestCHDSerialization(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, n.r, m.r)
 	assert.Equal(t, n.indices, m.indices)
-	assert.Equal(t, n.keys, m.keys)
-	assert.Equal(t, n.values, m.values)
+	cmpDataSlice(t, n, m, n.keys, m.keys)
+	cmpDataSlice(t, n, m, n.values, m.values)
 	for _, v := range words {
 		assert.Equal(t, []byte(v), n.Get([]byte(v)))
 	}
@@ -91,8 +99,8 @@ func TestCHDSerialization_empty(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, n.r, m.r)
 	assert.Equal(t, n.indices, m.indices)
-	assert.Equal(t, n.keys, m.keys)
-	assert.Equal(t, n.values, m.values)
+	cmpDataSlice(t, n, m, n.keys, m.keys)
+	cmpDataSlice(t, n, m, n.values, m.values)
 }
 
 func TestCHDSerialization_one(t *testing.T) {
@@ -108,8 +116,8 @@ func TestCHDSerialization_one(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, n.r, m.r)
 	assert.Equal(t, n.indices, m.indices)
-	assert.Equal(t, n.keys, m.keys)
-	assert.Equal(t, n.values, m.values)
+	cmpDataSlice(t, n, m, n.keys, m.keys)
+	cmpDataSlice(t, n, m, n.values, m.values)
 }
 
 func BenchmarkBuiltinMap(b *testing.B) {

--- a/slicereader_fast.go
+++ b/slicereader_fast.go
@@ -13,23 +13,26 @@ import (
 // written in little endian form, this of course means that this will only
 // work on little-endian architectures.
 type sliceReader struct {
-	b          []byte
-	start, end uint64
+	b   []byte
+	pos uint64
 }
 
 func (b *sliceReader) Read(size uint64) []byte {
-	b.start, b.end = b.end, b.end+size
-	return b.b[b.start:b.end]
+	start := b.pos
+	b.pos += size
+	return b.b[start:b.pos]
 }
 
 func (b *sliceReader) ReadUint64Array(n uint64) []uint64 {
-	b.start, b.end = b.end, b.end+n*8
-	return unsafeslice.Uint64SliceFromByteSlice(b.b[b.start:b.end])
+	start := b.pos
+	b.pos += n * 8
+	return unsafeslice.Uint64SliceFromByteSlice(b.b[start:b.pos])
 }
 
 func (b *sliceReader) ReadUint16Array(n uint64) []uint16 {
-	b.start, b.end = b.end, b.end+n*2
-	return unsafeslice.Uint16SliceFromByteSlice(b.b[b.start:b.end])
+	start := b.pos
+	b.pos += n * 2
+	return unsafeslice.Uint16SliceFromByteSlice(b.b[start:b.pos])
 }
 
 // Despite returning a uint64, this actually reads a uint32. All table indices

--- a/slicereader_safe.go
+++ b/slicereader_safe.go
@@ -8,19 +8,19 @@ import (
 
 // Read values and typed vectors from a byte slice without copying where possible.
 type sliceReader struct {
-	b          []byte
-	start, end uint64
+	b   []byte
+	pos uint64
 }
 
 func (b *sliceReader) Read(size uint64) []byte {
-	b.start, b.end = b.end, b.end+size
-	return b.b[b.start:b.end]
+	start := b.pos
+	b.pos += size
+	return b.b[start:b.pos]
 }
 
 func (b *sliceReader) ReadUint64Array(n uint64) []uint64 {
-	b.start, b.end = b.end, b.end+n*8
+	buf := b.Read(n * 8)
 	out := make([]uint64, n)
-	buf := b.b[b.start:b.end]
 	for i := 0; i < len(buf); i += 8 {
 		out[i>>3] = binary.LittleEndian.Uint64(buf[i : i+8])
 	}
@@ -28,9 +28,8 @@ func (b *sliceReader) ReadUint64Array(n uint64) []uint64 {
 }
 
 func (b *sliceReader) ReadUint16Array(n uint64) []uint16 {
-	b.start, b.end = b.end, b.end+n*2
+	buf := b.Read(n * 2)
 	out := make([]uint16, n)
-	buf := b.b[b.start:b.end]
 	for i := 0; i < len(buf); i += 2 {
 		out[i>>1] = binary.LittleEndian.Uint16(buf[i : i+2])
 	}


### PR DESCRIPTION
Just use ints pointing into the large byte slice.

Mmap() creates two `[]byte`s per key value pair. This creates
significant work for the garbage collector which has to scan through all
of these in each mark phase. For my 2.7M keys, it adds 5.4M pointers to
be scanned. By just using integers for offsets the garbage collector can
ignore it completely.

This does trade off some more work for the Builder which has to append
all the keys+values into a single byte slice.