### PR TITLE
Lower go.mod version to Go 1.17

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/alecthomas/mph
 
-go 1.21.6
+go 1.17
 
 require (
 	github.com/alecthomas/unsafeslice v0.2.0


### PR DESCRIPTION
This library can actually run with a really old Go version, but 1.17 seemed old enough to include most installations.